### PR TITLE
prevent crash on bgms[sheet.id] fails

### DIFF
--- a/Orchestrion/SongList.cs
+++ b/Orchestrion/SongList.cs
@@ -82,16 +82,16 @@ public static class SongList
             var location = elements[2].Substring(1).Replace("\"\"", "\"");
             var additionalInfo = elements[3].Substring(1, elements[3].Substring(1).Length - 1).Replace("\"\"", "\"");
 
-            var bgm = bgms[(uint)id];
+            bgms.TryGetValue((uint)id, out var bgm);
             var song = new Song
             {
                 Id = id,
                 Name = name,
                 Locations = location,
                 AdditionalInfo = additionalInfo,
-                SpecialMode = bgm.SpecialMode,
-                DisableRestart = bgm.DisableRestart,
-                FileExists = OrchestrionPlugin.DataManager.FileExists(bgm.File),
+                SpecialMode = bgm?.SpecialMode ?? 0,
+                DisableRestart = bgm?.DisableRestart ?? false,
+                FileExists = bgm != null && OrchestrionPlugin.DataManager.FileExists(bgm.File),
             };
 
             _songs[id] = song;


### PR DESCRIPTION
if `xiv_bgm.csv` contains a line with song ID that does not exist in BGM sheet, plogon will be crash; this PR does dirty null-check on it.

ps: can [red hightlighting on nonexistent song](https://github.com/lmcintyre/OrchestrionPlugin/commit/84a22d9c0f8ce347626daf04a1a090b1f87d9b2f#diff-dfadc30f7c2421f34779aa7586bb2598231efbe7f6816cf9b3f930bf5b195b6eL419) (removed on 84a22d9c) be added again? this made direct indication that '_hey you have illegal csv entry_' or somewhat.