### PR TITLE
Add Deep Dungeon mode

### DIFF
--- a/Orchestrion/Loc/en.json
+++ b/Orchestrion/Loc/en.json
@@ -127,6 +127,10 @@
     "message": "General Settings",
     "description": "SettingsWindow.Draw"
   },
+  "DDPlaylistAll": {
+    "message": "All Songs",
+    "description": "SettingsWindow.Draw"
+  },
   "AudioStreamingDisabledWarning": {
     "message": "Audio streaming is disabled. This may be due to Sound Filter or a third-party plugin. The above setting may not work as expected and you may encounter other audio issues such as popping or tracks not swapping channels. This is not related to the Orchestrion Plugin.",
     "description": "SettingsWindow.Draw"

--- a/Orchestrion/OrchestrionPlugin.cs
+++ b/Orchestrion/OrchestrionPlugin.cs
@@ -206,6 +206,9 @@ public class OrchestrionPlugin : IDalamudPlugin
 					case "repeat":
 						DalamudApi.ChatGui.PrintError(BuildChatMessage(Loc.Localize("NoRepeatModeSpecified", "Please specify a repeat mode.")));
 						break;
+					case "ddmode":
+						BGMManager.StartDeepDungeonMode();
+						break;
 				}
 				break;
 			case 2:
@@ -254,7 +257,10 @@ public class OrchestrionPlugin : IDalamudPlugin
 							PlaylistManager.CurrentPlaylist.ShuffleMode = ShuffleMode.Off;
 							PlaylistManager.CurrentPlaylist.RepeatMode = repeatMode;
 						}
-						break;	
+						break;
+					case "ddmode":
+						BGMManager.StartDeepDungeonMode(argSplit[1]);
+						break;
 				}
 				break;
 			case >= 3 when argSplit[1].ToLowerInvariant() == "playlist":
@@ -323,6 +329,7 @@ public class OrchestrionPlugin : IDalamudPlugin
 		DalamudApi.ChatGui.Print(BuildChatMessage("/porch play [song name] - " + Loc.Localize("HelpPlaySongWithName", "Play the song with the specified name (both English and Japanese titles work)")));
 		DalamudApi.ChatGui.Print(BuildChatMessage("/porch random - " + Loc.Localize("HelpPlayRandomSong", "Play a random song")));
 		DalamudApi.ChatGui.Print(BuildChatMessage("/porch stop - " + Loc.Localize("HelpStopSong", "Stop the current playing song, replacement song, or playlist")));
+		DalamudApi.ChatGui.Print(BuildChatMessage("/porch ddmode [playlist] - " + Loc.Localize("HelpDDMode", "On every in-game BGM change replace BGM with random song from specified playlist")));
 		DalamudApi.ChatGui.Print(BuildChatMessage(Loc.Localize("PlaylistCommandsColon", "Playlist Commands:")));
 		DalamudApi.ChatGui.Print(BuildChatMessage("/porch random [playlist] - " + Loc.Localize("HelpPlayRandomSongFromPlaylist", "Play a random song from the specified playlist (does not begin the playlist)")));
 		DalamudApi.ChatGui.Print(BuildChatMessage("/porch play playlist [playlist name] - " + Loc.Localize("HelpPlayPlaylist", "Play the specified playlist with its current settings")));

--- a/Orchestrion/UI/Windows/MainWindow/MainWindow.DDMode.cs
+++ b/Orchestrion/UI/Windows/MainWindow/MainWindow.DDMode.cs
@@ -1,0 +1,56 @@
+﻿using CheapLoc;
+using ImGuiNET;
+using Orchestrion.Audio;
+using Orchestrion.Persistence;
+using Orchestrion.Struct;
+
+namespace Orchestrion.UI.Windows.MainWindow;
+
+public partial class MainWindow
+{
+    private string _selectedDDPlaylist = "";
+    private void DrawDeepDungeonModeTab()
+    {
+        ImGui.BeginChild("##ddmode");
+        DrawDeepDungeonModeSelector();
+        ImGui.EndChild();
+    }
+
+    private void DrawDeepDungeonModeSelector()
+    {
+        ImGui.Spacing();
+
+        var targetText = $"{SongList.Instance.GetSong(_tmpReplacement.TargetSongId).Id} - {SongList.Instance.GetSong(_tmpReplacement.TargetSongId).Name}";
+        string replacementText;
+        if (_tmpReplacement.ReplacementId == SongReplacementEntry.NoChangeId)
+            replacementText = _noChange;
+        else
+            replacementText = $"{SongList.Instance.GetSong(_tmpReplacement.ReplacementId).Id} - {SongList.Instance.GetSong(_tmpReplacement.ReplacementId).Name}";
+
+        // This fixes the ultra-wide combo boxes, I guess
+        var width = ImGui.GetWindowWidth() * 0.60f;
+
+        string allSongsLoc = Loc.Localize("DDPlaylistAll", "All Songs");
+        if (ImGui.BeginCombo(Loc.Localize("DDPlaylist", "Playlist"), _selectedDDPlaylist == "" ? allSongsLoc : _selectedDDPlaylist))
+        {
+            if (ImGui.Selectable(allSongsLoc))
+            {
+                _selectedDDPlaylist = "";
+            }
+            foreach (var pInfo in Configuration.Instance.Playlists)
+            {
+                var pName = pInfo.Key;
+                if (ImGui.Selectable(pName))
+                {
+                    _selectedDDPlaylist = pName;
+                }
+            }
+            ImGui.EndCombo();
+        }
+        var text = Loc.Localize("DDModeStart", "Start DD Mode");
+        if (ImGui.Button(text))
+        {
+            BGMManager.StartDeepDungeonMode(_selectedDDPlaylist);
+        }
+    }
+}

--- a/Orchestrion/UI/Windows/MainWindow/MainWindow.Root.cs
+++ b/Orchestrion/UI/Windows/MainWindow/MainWindow.Root.cs
@@ -23,6 +23,7 @@ public partial class MainWindow : Window, IDisposable
 	{
 		AllSongs,
 		Playlist,
+		DDMode,
 		History,
 		Replacements,
 		Debug,
@@ -159,6 +160,7 @@ public partial class MainWindow : Window, IDisposable
 		{
 			DrawTab(Loc.Localize("AllSongs", "All Songs"), "orch_AllSongs", DrawSongListTab, TabType.AllSongs);
 			DrawTab(Loc.Localize("Playlists", "Playlists"), "orch_Playlists", DrawPlaylistsTab, TabType.Playlist);
+			DrawTab(Loc.Localize("DDMode", "DDMode"), "orch_DDMode", DrawDeepDungeonModeTab, TabType.DDMode);
 			DrawTab(Loc.Localize("History", "History"), "orch_History", DrawSongHistoryTab, TabType.History);
 			DrawTab(Loc.Localize("Replacements", "Replacements"), "orch_Replacements", DrawReplacementsTab, TabType.Replacements);
 #if DEBUG


### PR DESCRIPTION
Something that I personally wanted, but may be it would be useful to someone else.

Deep Dungeon mode, aka "Replace BGM on in-game BGM change with a random one". Can be used with all songs or with a user created playlist.

Command line usage:
```
/porch ddmode [playlist]
```

Stops with the same `/porch stop` command.

There's a very basic GUI tab as well.