### PR TITLE
Use a single space in DTR entry

### DIFF
--- a/Orchestrion/OrchestrionPlugin.cs
+++ b/Orchestrion/OrchestrionPlugin.cs
@@ -430,7 +430,7 @@ public class OrchestrionPlugin : IDalamudPlugin
 
 		var text = songName + suffix;
 
-		text = playedByOrch ? $"{NativeNowPlayingPrefix} [{text}]" : $"{NativeNowPlayingPrefix} {text}";
+		text = playedByOrch ? $"{NativeNowPlayingPrefix}[{text}]" : $"{NativeNowPlayingPrefix}{text}";
 		
 		_dtrEntry.Text = text;
 


### PR DESCRIPTION
Before this change, there was a space in the interpolated string and a space in the NativeNowPlayingPrefix, which caused a large gap between the eighth-note symbol and the song name.  It was most noticeable with other plugins that put entries in the DTR, because the two-space gap is similar to the default Dalamud spacing between entries.

I felt it best to concatenate the prefix and song title without a space between them.

This change also better approximates native UI spacing between symbol and associated text.

Before:
![image](https://github.com/user-attachments/assets/748ebcdc-4c57-486c-961c-8d0a183b6297)

After:
![image](https://github.com/user-attachments/assets/1ed1521f-a894-4241-82e7-a001f9c3c6cf)


Resolves lmcintyre/OrchestrionPlugin#57.