### PR TITLE
Only modify DtrBarEntry.Shown when show state changes

### DIFF
--- a/Orchestrion/OrchestrionPlugin.cs
+++ b/Orchestrion/OrchestrionPlugin.cs
@@ -147,7 +147,9 @@ public class OrchestrionPlugin : IDalamudPlugin
 
 	private void CheckDtr()
 	{
-		_dtrEntry.Shown = Configuration.Instance.ShowSongInNative;
+		var show = Configuration.Instance.ShowSongInNative;
+		if (_dtrEntry.Shown != show)
+			_dtrEntry.Shown = show;
 	}
 	
 	private void UpdateSettings()


### PR DESCRIPTION
A very small change to check the state of `DtrBarEntry.Shown` before setting it. By doing it this way we avoid setting the internal `isDirty` flag on the `DtrBarEntry` each frame and prevent Dalamud from re-rendering the entry when noting has changed.