### PR TITLE
fix: use EN song info when selected language info not exist

### DIFF
--- a/Orchestrion/OrchestrionPlugin.cs
+++ b/Orchestrion/OrchestrionPlugin.cs
@@ -20,6 +20,7 @@ using Orchestrion.BGMSystem;
 using Orchestrion.Persistence;
 using Orchestrion.UI.Windows;
 using MainWindow = Orchestrion.UI.Windows.MainWindow.MainWindow;
+using Orchestrion.Types;
 
 namespace Orchestrion;
 
@@ -417,9 +418,14 @@ public class OrchestrionPlugin : IDalamudPlugin
 	{
 		if (_dtrEntry == null) return;
 		if (!SongList.Instance.TryGetSong(songId, out var song)) return;
-		var songName = song.Strings[Configuration.Instance.ServerInfoLanguageCode].Name;
-		var locations = song.Strings[Configuration.Instance.ServerInfoLanguageCode].Locations;
-		var info = song.Strings[Configuration.Instance.ServerInfoLanguageCode].AdditionalInfo;
+
+		if (!song.Strings.TryGetValue(Configuration.Instance.ServerInfoLanguageCode, out var strings)) {
+			strings = song.Strings["en"];
+		}
+
+		var songName = strings.Name;
+		var locations = strings.Locations;
+		var info = strings.AdditionalInfo;
 		if (string.IsNullOrEmpty(songName)) return;
 
 		var suffix = "";

--- a/Orchestrion/UI/Components/BgmTooltip.cs
+++ b/Orchestrion/UI/Components/BgmTooltip.cs
@@ -31,15 +31,21 @@ public static class BgmTooltip
 		if (Configuration.Instance.ShowAltLangTitles)
 		{
 			var code = Configuration.Instance.AltTitleLanguageCode;
-			var altLangTitle = bgm.Strings[code].Name;
-			if (bgm.Name != altLangTitle && !string.IsNullOrEmpty(altLangTitle))
+
+			if (bgm.Strings.TryGetValue(code, out var altLangStrings) && altLangStrings.Name != bgm.Name && !string.IsNullOrEmpty(altLangStrings.Name)) {
+				DisplayDetail(altLangStrings);
+			} else if (bgm.Strings.TryGetValue("en", out altLangStrings) && altLangStrings.Name != bgm.Name && !string.IsNullOrEmpty(altLangStrings.Name)) {
+				DisplayDetail(altLangStrings);
+			}
+
+				void DisplayDetail(SongStrings altLangStrings)
 			{
 				var label = Loc.Localize("TitleColon", "Title: ");
 				label = $"[{code}] {label}";
 				ImGui.TextColored(ImGuiColors.DalamudGrey, label);
 				ImGui.SameLine();
 				using var _ = code == "zh" ? OrchestrionPlugin.CnFont.Push() : null;
-				ImGui.TextWrapped(altLangTitle);
+				ImGui.TextWrapped(altLangStrings.Name);
 			}
 		}
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b8545e78-2f8c-4f00-ac29-99a7de1ebd92)

A exception would be thrown when `bgm.Strings[code]` is not exist.